### PR TITLE
Pelasne/add time to usage

### DIFF
--- a/inference/Program.cs
+++ b/inference/Program.cs
@@ -58,8 +58,8 @@ builder.Services.AddSingleton(provider =>
             config.LLM_API_KEY)
         .AddAzureOpenAITextEmbeddingGeneration(
             config.EMBEDDING_DEPLOYMENT_NAME,
-            config.LLM_ENDPOINT_URI,
-            config.LLM_API_KEY);
+            config.EMBEDDING_ENDPOINT_URI,
+            config.EMBEDDING_API_KEY);
 
     kernalBuilder.AddOpenTelemetry(builder.Environment.ApplicationName, config.OPEN_TELEMETRY_CONNECTION_STRING);
     return kernalBuilder.Build();

--- a/inference/config/Config.cs
+++ b/inference/config/Config.cs
@@ -15,11 +15,11 @@ public class Config : IConfig
         this.OPEN_TELEMETRY_CONNECTION_STRING = config.GetSecret<string>("OPEN_TELEMETRY_CONNECTION_STRING").Result;
         this.MEMORY_TERM = config.Get<string>("MEMORY_TERM").AsEnum(() => MemoryTerm.Long);
         this.LLM_DEPLOYMENT_NAME = config.Get<string>("LLM_DEPLOYMENT_NAME");
-        this.LLM_ENDPOINT_URI = config.Get<string>("LLM_ENDPOINT_URI");
-        this.LLM_API_KEY = config.GetSecret<string>("LLM_API_KEY").Result;
+        this.LLM_ENDPOINT_URI = config.Get<string>("LLM_ENDPOINT_URI, ENDPOINT_URI");
+        this.LLM_API_KEY = config.GetSecret<string>("LLM_API_KEY, API_KEY").Result;
         this.EMBEDDING_DEPLOYMENT_NAME = config.Get<string>("EMBEDDING_DEPLOYMENT_NAME");
-        this.EMBEDDING_ENDPOINT_URI = config.Get<string>("EMBEDDING_ENDPOINT_URI");
-        this.EMBEDDING_API_KEY = config.GetSecret<string>("EMBEDDING_API_KEY").Result;
+        this.EMBEDDING_ENDPOINT_URI = config.Get<string>("EMBEDDING_ENDPOINT_URI, ENDPOINT_URI");
+        this.EMBEDDING_API_KEY = config.GetSecret<string>("EMBEDDING_API_KEY, API_KEY").Result;
         this.LLM_MODEL_NAME = config.Get<string>("LLM_MODEL_NAME").AsString(() => this.LLM_DEPLOYMENT_NAME);
         this.LLM_ENCODING_MODEL = "TBD";
         this.SEARCH_INDEX = config.Get<string>("SEARCH_INDEX");

--- a/inference/config/Config.cs
+++ b/inference/config/Config.cs
@@ -15,9 +15,11 @@ public class Config : IConfig
         this.OPEN_TELEMETRY_CONNECTION_STRING = config.GetSecret<string>("OPEN_TELEMETRY_CONNECTION_STRING").Result;
         this.MEMORY_TERM = config.Get<string>("MEMORY_TERM").AsEnum(() => MemoryTerm.Long);
         this.LLM_DEPLOYMENT_NAME = config.Get<string>("LLM_DEPLOYMENT_NAME");
-        this.EMBEDDING_DEPLOYMENT_NAME = config.Get<string>("EMBEDDING_DEPLOYMENT_NAME");
         this.LLM_ENDPOINT_URI = config.Get<string>("LLM_ENDPOINT_URI");
         this.LLM_API_KEY = config.GetSecret<string>("LLM_API_KEY").Result;
+        this.EMBEDDING_DEPLOYMENT_NAME = config.Get<string>("EMBEDDING_DEPLOYMENT_NAME");
+        this.EMBEDDING_ENDPOINT_URI = config.Get<string>("EMBEDDING_ENDPOINT_URI");
+        this.EMBEDDING_API_KEY = config.GetSecret<string>("EMBEDDING_API_KEY").Result;
         this.LLM_MODEL_NAME = config.Get<string>("LLM_MODEL_NAME").AsString(() => this.LLM_DEPLOYMENT_NAME);
         this.LLM_ENCODING_MODEL = "TBD";
         this.SEARCH_INDEX = config.Get<string>("SEARCH_INDEX");
@@ -43,11 +45,15 @@ public class Config : IConfig
 
     public string LLM_DEPLOYMENT_NAME { get; }
 
-    public string EMBEDDING_DEPLOYMENT_NAME { get; }
-
     public string LLM_ENDPOINT_URI { get; }
 
     public string LLM_API_KEY { get; }
+
+    public string EMBEDDING_DEPLOYMENT_NAME { get; }
+
+    public string EMBEDDING_ENDPOINT_URI { get; }
+
+    public string EMBEDDING_API_KEY { get; }
 
     public string LLM_MODEL_NAME { get; }
 
@@ -82,9 +88,11 @@ public class Config : IConfig
         this.config.Require("OPEN_TELEMETRY_CONNECTION_STRING", this.OPEN_TELEMETRY_CONNECTION_STRING, hideValue: true);
         this.config.Require("MEMORY_TERM", this.MEMORY_TERM.ToString());
         this.config.Require("LLM_DEPLOYMENT_NAME", this.LLM_DEPLOYMENT_NAME);
-        this.config.Require("EMBEDDING_DEPLOYMENT_NAME", this.EMBEDDING_DEPLOYMENT_NAME);
         this.config.Require("LLM_ENDPOINT_URI", this.LLM_ENDPOINT_URI);
         this.config.Require("LLM_API_KEY", this.LLM_API_KEY, hideValue: true);
+        this.config.Require("EMBEDDING_DEPLOYMENT_NAME", this.EMBEDDING_DEPLOYMENT_NAME);
+        this.config.Require("EMBEDDING_ENDPOINT_URI", this.EMBEDDING_ENDPOINT_URI);
+        this.config.Require("EMBEDDING_API_KEY", this.EMBEDDING_API_KEY, hideValue: true);
 
         this.config.Require("LLM_MODEL_NAME", this.LLM_MODEL_NAME);
         this.LLM_ENCODING_MODEL = Model.GetEncodingNameForModel(this.LLM_MODEL_NAME);

--- a/inference/config/IConfig.cs
+++ b/inference/config/IConfig.cs
@@ -7,9 +7,11 @@ public interface IConfig
     MemoryTerm MEMORY_TERM { get; }
     string OPEN_TELEMETRY_CONNECTION_STRING { get; }
     string LLM_DEPLOYMENT_NAME { get; }
-    string EMBEDDING_DEPLOYMENT_NAME { get; }
     string LLM_ENDPOINT_URI { get; }
     string LLM_API_KEY { get; }
+    string EMBEDDING_DEPLOYMENT_NAME { get; }
+    string EMBEDDING_ENDPOINT_URI { get; }
+    string EMBEDDING_API_KEY { get; }
     string LLM_MODEL_NAME { get; }
     string LLM_ENCODING_MODEL { get; set; }
     string SEARCH_INDEX { get; }

--- a/inference/models/Usage.cs
+++ b/inference/models/Usage.cs
@@ -9,4 +9,7 @@ public class Usage
 
     [JsonProperty("completion_token_count", Required = Required.Always)]
     public int CompletionTokenCount { get; set; }
+
+    [JsonProperty("execution_time", Required = Required.Always)]
+    public long ExecutionTime { get; set; }
 }

--- a/inference/steps/InDomainOnlyWorkflow.cs
+++ b/inference/steps/InDomainOnlyWorkflow.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Shared;
 
 namespace Inference;
@@ -11,7 +12,8 @@ public class InDomainOnlyWorkflow(
     ApplyIntent applyIntent,
     GetDocuments getDocuments,
     SelectGroundingData selectGroundingData,
-    GenerateAnswer generateAnswer)
+    GenerateAnswer generateAnswer,
+    ILogger<InDomainOnlyWorkflow> logger)
     : IWorkflow
 {
     private readonly InDomainOnlyIntent inDomainOnly = inDomainOnly;
@@ -19,6 +21,7 @@ public class InDomainOnlyWorkflow(
     private readonly GetDocuments getDocuments = getDocuments;
     private readonly SelectGroundingData selectGroundingData = selectGroundingData;
     private readonly GenerateAnswer generateAnswer = generateAnswer;
+    private readonly ILogger<InDomainOnlyWorkflow> logger = logger;
 
     public async Task<WorkflowResponse> Execute(
         WorkflowRequest workflowRequest,
@@ -63,7 +66,8 @@ public class InDomainOnlyWorkflow(
         }
         catch (Exception ex)
         {
-            throw new HttpWithResponseException(500, ex.Message, response);
+            this.logger.LogError(ex, "An error occurred while executing the in-domain-only workflow.");
+            throw new HttpWithResponseException(500, $"{ex.GetType()}: {ex.Message}", response);
         }
     }
 }

--- a/inference/steps/PrimaryWorkflow.cs
+++ b/inference/steps/PrimaryWorkflow.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Shared;
 
 namespace Inference;
@@ -11,7 +12,8 @@ public class PrimaryWorkflow(
     ApplyIntent applyIntent,
     GetDocuments getDocuments,
     SelectGroundingData selectGroundingData,
-    GenerateAnswer generateAnswer)
+    GenerateAnswer generateAnswer,
+    ILogger<PrimaryWorkflow> logger)
     : IWorkflow
 {
     private readonly DetermineIntent determineIntent = determineIntent;
@@ -19,6 +21,7 @@ public class PrimaryWorkflow(
     private readonly GetDocuments getDocuments = getDocuments;
     private readonly SelectGroundingData selectGroundingData = selectGroundingData;
     private readonly GenerateAnswer generateAnswer = generateAnswer;
+    private readonly ILogger<PrimaryWorkflow> logger = logger;
 
     public async Task<WorkflowResponse> Execute(
         WorkflowRequest workflowRequest,
@@ -63,7 +66,8 @@ public class PrimaryWorkflow(
         }
         catch (Exception ex)
         {
-            throw new HttpWithResponseException(500, ex.Message, response);
+            this.logger.LogError(ex, "An error occurred while executing the primary workflow.");
+            throw new HttpWithResponseException(500, $"{ex.GetType()}: {ex.Message}", response);
         }
     }
 }


### PR DESCRIPTION
This PR addresses a few things:
1. The LLM and EMBEDDING models can be in the same or different regions.
2. When the workflow returns a 500 it also logs to the ILogger what the actual error was.
3. The steps now report an "execution_time" in milliseconds.